### PR TITLE
Specify releases / use builtin functionality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 python: "2.7"
 env:
   matrix:
-    - ANSIBLE_VERSION="2.1.6"
+    - ANSIBLE_VERSION="2.2.3"
     - ANSIBLE_VERSION="2.4.2.0"
 before_install:
  - sudo apt-get update -qq

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 python: "2.7"
 env:
   matrix:
-    - ANSIBLE_VERSION="2.2.3"
+    - ANSIBLE_VERSION="2.3.2"
     - ANSIBLE_VERSION="2.4.2.0"
 before_install:
  - sudo apt-get update -qq

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: python
 python: "2.7"
 env:
   matrix:
-    - ANSIBLE_VERSION="1.9.4"
-    - ANSIBLE_VERSION="2.0.0.2"
+    - ANSIBLE_VERSION="2.1"
+    - ANSIBLE_VERSION="2.4.2.0"
 before_install:
  - sudo apt-get update -qq
  - sudo apt-get install -qq python-apt python-pycurl

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 python: "2.7"
 env:
   matrix:
-    - ANSIBLE_VERSION="2.1"
+    - ANSIBLE_VERSION="2.1.6"
     - ANSIBLE_VERSION="2.4.2.0"
 before_install:
  - sudo apt-get update -qq

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,3 +13,8 @@ apt_autoclean: yes                        # remove .deb files for packages no lo
 apt_default_packages:
   - python-apt
   - unattended-upgrades
+  - apt-transport-https
+  - curl
+  - ca-certificates
+  - software-properties-common
+apt_release: precise                      # What release to pull from

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   author: pjan vandaele
   company: ANXS
   description: Manages apt and executes apt-get update to ensure the local APT package cache is up to date.
-  min_ansible_version: 1.4
+  min_ansible_version: 2.1
   license: MIT
   platforms:
   - name: Ubuntu

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   author: pjan vandaele
   company: ANXS
   description: Manages apt and executes apt-get update to ensure the local APT package cache is up to date.
-  min_ansible_version: 2.2.3
+  min_ansible_version: 2.3.2
   license: MIT
   platforms:
   - name: Ubuntu

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   author: pjan vandaele
   company: ANXS
   description: Manages apt and executes apt-get update to ensure the local APT package cache is up to date.
-  min_ansible_version: 2.1
+  min_ansible_version: 2.1.6
   license: MIT
   platforms:
   - name: Ubuntu

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   author: pjan vandaele
   company: ANXS
   description: Manages apt and executes apt-get update to ensure the local APT package cache is up to date.
-  min_ansible_version: 2.1.6
+  min_ansible_version: 2.2.3
   license: MIT
   platforms:
   - name: Ubuntu

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,16 +15,14 @@
     cache_valid_time: "{{apt_cache_valid_time}}"
 
 - name: APT | Remove packages that are no longer needed for dependencies
-  shell: apt-get -y autoremove
+  apt:
+    autoremove: true
   when: apt_autoremove
-  register: autoremove_output
-  changed_when: "'0 upgraded, 0 newly installed, 0 to remove' not in autoremove_output.stdout and 'not upgraded' not in autoremove_output.stdout"
 
 - name: APT | Remove .deb files for packages no longer on your system
-  shell: apt-get -y autoclean
+  apt:
+    autoclean: true
   when: apt_autoclean
-  register: autoclean_output
-  changed_when: "'Del' in autoclean_output.stdout"
 
 - name: APT | Check for cached .deb files
   shell: "ls /var/cache/apt/archives/*.deb 2&> /dev/null | wc -l"

--- a/templates/etc_apt_sources.list.j2
+++ b/templates/etc_apt_sources.list.j2
@@ -1,20 +1,20 @@
 # See http://help.ubuntu.com/community/UpgradeNotes for how to upgrade to
 # newer versions of the distribution.
-deb {{ apt_mirror_url }}/ubuntu/ precise main restricted
-deb-src {{ apt_mirror_url }}/ubuntu/ precise main restricted
+deb {{ apt_mirror_url }}/ubuntu/ {{ apt_release }} main restricted
+deb-src {{ apt_mirror_url }}/ubuntu/ {{ apt_release }} main restricted
 
 ## Major bug fix updates produced after the final release of the
 ## distribution.
-deb {{ apt_mirror_url }}/ubuntu/ precise-updates main restricted
-deb-src {{ apt_mirror_url }}/ubuntu/ precise-updates main restricted
+deb {{ apt_mirror_url }}/ubuntu/ {{ apt_release }}-updates main restricted
+deb-src {{ apt_mirror_url }}/ubuntu/ {{ apt_release }}-updates main restricted
 
 ## N.B. software from this repository is ENTIRELY UNSUPPORTED by the Ubuntu
 ## team. Also, please note that software in universe WILL NOT receive any
 ## review or updates from the Ubuntu security team.
-deb {{ apt_mirror_url }}/ubuntu/ precise universe
-deb-src {{ apt_mirror_url }}/ubuntu/ precise universe
-deb {{ apt_mirror_url }}/ubuntu/ precise-updates universe
-deb-src {{ apt_mirror_url }}/ubuntu/ precise-updates universe
+deb {{ apt_mirror_url }}/ubuntu/ {{ apt_release }} universe
+deb-src {{ apt_mirror_url }}/ubuntu/ {{ apt_release }} universe
+deb {{ apt_mirror_url }}/ubuntu/ {{ apt_release }}-updates universe
+deb-src {{ apt_mirror_url }}/ubuntu/ {{ apt_release }}-updates universe
 
 ## N.B. software from this repository is ENTIRELY UNSUPPORTED by the Ubuntu
 ## team, and may not be under a free licence. Please satisfy yourself as to
@@ -22,36 +22,36 @@ deb-src {{ apt_mirror_url }}/ubuntu/ precise-updates universe
 ## multiverse WILL NOT receive any review or updates from the Ubuntu
 ## security team.
 
-deb {{ apt_mirror_url }}/ubuntu/ precise multiverse
-deb-src {{ apt_mirror_url }}/ubuntu/ precise multiverse
-deb {{ apt_mirror_url }}/ubuntu/ precise-updates multiverse
-deb-src {{ apt_mirror_url }}/ubuntu/ precise-updates multiverse
+deb {{ apt_mirror_url }}/ubuntu/ {{ apt_release }} multiverse
+deb-src {{ apt_mirror_url }}/ubuntu/ {{ apt_release }} multiverse
+deb {{ apt_mirror_url }}/ubuntu/ {{ apt_release }}-updates multiverse
+deb-src {{ apt_mirror_url }}/ubuntu/ {{ apt_release }}-updates multiverse
 
 ## N.B. software from this repository may not have been tested as
 ## extensively as that contained in the main release, although it includes
 ## newer versions of some applications which may provide useful features.
 ## Also, please note that software in backports WILL NOT receive any review
 ## or updates from the Ubuntu security team.
-deb {{ apt_mirror_url }}/ubuntu/ precise-backports main restricted universe multiverse
-deb-src {{ apt_mirror_url }}/ubuntu/ precise-backports main restricted universe multiverse
+deb {{ apt_mirror_url }}/ubuntu/ {{ apt_release }}-backports main restricted universe multiverse
+deb-src {{ apt_mirror_url }}/ubuntu/ {{ apt_release }}-backports main restricted universe multiverse
 
-deb http://security.ubuntu.com/ubuntu precise-security main restricted
-deb-src http://security.ubuntu.com/ubuntu precise-security main restricted
-deb http://security.ubuntu.com/ubuntu precise-security universe
-deb-src http://security.ubuntu.com/ubuntu precise-security universe
-deb http://security.ubuntu.com/ubuntu precise-security multiverse
-deb-src http://security.ubuntu.com/ubuntu precise-security multiverse
+deb http://security.ubuntu.com/ubuntu {{ apt_release }}-security main restricted
+deb-src http://security.ubuntu.com/ubuntu {{ apt_release }}-security main restricted
+deb http://security.ubuntu.com/ubuntu {{ apt_release }}-security universe
+deb-src http://security.ubuntu.com/ubuntu {{ apt_release }}-security universe
+deb http://security.ubuntu.com/ubuntu {{ apt_release }}-security multiverse
+deb-src http://security.ubuntu.com/ubuntu {{ apt_release }}-security multiverse
 
 ## Uncomment the following two lines to add software from Canonical's
 ## 'partner' repository.
 ## This software is not part of Ubuntu, but is offered by Canonical and the
 ## respective vendors as a service to Ubuntu users.
-# deb http://archive.canonical.com/ubuntu precise partner
-# deb-src http://archive.canonical.com/ubuntu precise partner
+# deb http://archive.canonical.com/ubuntu {{ apt_release }} partner
+# deb-src http://archive.canonical.com/ubuntu {{ apt_release }} partner
 
 ## Uncomment the following two lines to add software from Ubuntu's
 ## 'extras' repository.
 ## This software is not part of Ubuntu, but is offered by third-party
 ## developers who want to ship their latest software.
-# deb http://extras.ubuntu.com/ubuntu precise main
-# deb-src http://extras.ubuntu.com/ubuntu precise main
+# deb http://extras.ubuntu.com/ubuntu {{ apt_release }} main
+# deb-src http://extras.ubuntu.com/ubuntu {{ apt_release }} main


### PR DESCRIPTION
Addresses #10. Also uses builtin `apt` module functionality. Note that this is a _technically_ a breaking change as the minimum supported version of Ansible is much higher now (2.3.2).